### PR TITLE
Universal pseudoscalar I and × cross product

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,9 +15,9 @@ This package is a work in progress providing the necessary tools to work with ar
 
 It is currently possible to do both high-performance numerical computations with `Grassmann` and it is also currently possible to use symbolic scalar coefficients when the `Reduce` package is also loaded (compatibility instructions at bottom).
 
-Products available for high-performance and sparse computation include `∧,∨,⋅,*` (exterior, regressive, interior, geometric).
+Products available for sparse & high-performance ops include `∧,∨,⋅,*,×` (exterior, regressive, interior, geometric, cross).
 
-Some unary operations include `complementleft`,`complementright`,`reverse,`,`involve`,`conj`, and `adjoint`.
+Some unary operations include `complementleft`,`complementright`,`reverse`,`involute`,`conj`, and `adjoint`.
 
 #### Design, code generation
 

--- a/README.md
+++ b/README.md
@@ -131,8 +131,11 @@ v₂₃
 ```
 Effort of computation depends on the sparsity. Then it is possible to assign the **quaternion** generators `i,j,k` with
 ```Julia
-julia> i,j,k = complementright.((-Λ(3).v1,-Λ(3).v2,-Λ(3).v3))
-(-1v₂₃, 1v₁₃, -1v₁₂)
+julia> i,j,k = hyperplanes(ℝ^3)
+3-element Array{SValue{⟨+++⟩,2,B,Int64} where B,1}:
+ -1v₂₃
+ 1v₁₃
+ -1v₁₂
 
 julia> @btime i^2, j^2, k^2, i*j*k
   158.925 ns (5 allocations: 112 bytes)

--- a/src/Grassmann.jl
+++ b/src/Grassmann.jl
@@ -17,6 +17,12 @@ include("forms.jl")
 include("symbolic.jl")
 include("generators.jl")
 
+## fundamentals
+
+export hyperplanes
+
+hyperplanes(V::VectorSpace{N}) where N = map(n->I*getbasis(V,1<<n),0:N-1)
+
 abstract type SubAlgebra{V} <: TensorAlgebra{V} end
 
 adjoint(G::A) where A<:SubAlgebra{V} where V = Λ(dual(V))

--- a/src/multivectors.jl
+++ b/src/multivectors.jl
@@ -388,7 +388,7 @@ end
 
 ## conversions
 
-@inline (V::VectorSpace)(s::UniformScaling{T}) where T = SValue{V}(T<:Bool ? (s.λ ? -(one(T)) : one(T)) : s.λ,getbasis(V,(one(Bits)<<ndims(V))-1))
+@inline (V::VectorSpace)(s::UniformScaling{T}) where T = SValue{V}(T<:Bool ? (s.λ ? one(Int) : -(one(Int))) : s.λ,getbasis(V,(one(T)<<ndims(V))-1))
 
 @pure function (W::VectorSpace)(b::Basis{V}) where V
     V==W && (return b)

--- a/src/multivectors.jl
+++ b/src/multivectors.jl
@@ -11,6 +11,12 @@ abstract type TensorMixed{T,V} <: TensorAlgebra{V} end
 
 import DirectSum: shift_indices, printindex, printindices, VTI
 
+## pseudoscalar
+
+using LinearAlgebra
+import LinearAlgebra: I
+export UniformScaling, I
+
 ## MultiBasis{N}
 
 struct Basis{V,G,B} <: TensorTerm{V,G}
@@ -381,6 +387,8 @@ function adjoint(b::Basis{V,G,B}) where {V,G,B}
 end
 
 ## conversions
+
+@inline (V::VectorSpace)(s::UniformScaling{T}) where T = SValue{V}(T<:Bool ? (s.λ ? -(one(T)) : one(T)) : s.λ,getbasis(V,(one(Bits)<<ndims(V))-1))
 
 @pure function (W::VectorSpace)(b::Basis{V}) where V
     V==W && (return b)

--- a/src/symbolic.jl
+++ b/src/symbolic.jl
@@ -32,33 +32,48 @@ for (op,set) ∈ ((:add,:(+=)),(:set,:(=)))
             return m
         end
         @inline function $(Symbol(:meet,sm))(V::VectorSpace{N,D},m::SizedArray{Tuple{M},T,1,1},A::Bits,B::Bits,v::T) where {N,D,T<:SymField,M}
-            if v ≠ 0
-                p,C,t = regressive(N,value(V),A,B)
+            if v ≠ 0 && !(hasdual(V) && hasdual(A) && hasdual(B))
+                p,C,t = regressive(A,B,V)
                 t && $sm(m,p ? $Sym.:-(v) : v,C,Dimension{N}())
             end
             return m
         end
         @inline function $(Symbol(:meet,sm))(m::SizedArray{Tuple{M},T,1,1},A::Basis{V},B::Basis{V},v::T) where {V,T<:SymField,M}
-            if v ≠ 0
-                p,C,t = regressive(N,value(V),bits(A),bits(B))
+            if v ≠ 0 && !(hasdual(V) && hasdual(A) && hasdual(B))
+                p,C,t = regressive(bits(A),bits(B),V)
                 t && $sm(m,p ? $Sym.:-(v) : v,C,Dimension{N}())
             end
             return m
         end
         @inline function $(Symbol(:skew,sm))(V::VectorSpace{N,D},m::SizedArray{Tuple{M},T,1,1},A::Bits,B::Bits,v::T) where {N,D,T<:SymField,M}
-            if v ≠ 0
-                p,C,t = interior(N,value(V),A,B)
+            if v ≠ 0 && !(hasdual(V) && hasdual(A) && hasdual(B))
+                p,C,t = interior(A,B,V)
                 t && $sm(m,p ? $Sym.:-(v) : v,C,Dimension{N}())
             end
             return m
         end
         @inline function $(Symbol(:skew,sm))(m::SizedArray{Tuple{M},T,1,1},A::Basis{V},B::Basis{V},v::T) where {V,T<:SymField,M}
-            if v ≠ 0
-                p,C,t = interior(N,value(V),bits(A),bits(B))
+            if v ≠ 0 && !(hasdual(V) && hasdual(A) && hasdual(B))
+                p,C,t = interior(bits(A),bits(B),V)
                 t && $sm(m,p ? $Sym.:-(v) : v,C,Dimension{N}())
             end
             return m
         end
+        @inline function $(Symbol(:cross,sm))(V::VectorSpace{N,D},m::SizedArray{Tuple{M},T,1,1},A::Bits,B::Bits,v::T) where {N,D,T<:SymField,M}
+            if v ≠ 0 && !(hasdual(V) && hasdual(A) && hasdual(B))
+                p,C,t = crossprod(A,B,V)
+                t && $sm(m,p ? $Sym.:-(v) : v,C,Dimension{N}())
+            end
+            return m
+        end
+        @inline function $(Symbol(:cross,sm))(m::SizedArray{Tuple{M},T,1,1},A::Basis{V},B::Basis{V},v::T) where {V,T<:SymField,M}
+            if v ≠ 0 && !(hasdual(V) && hasdual(A) && hasdual(B))
+                p,C,t = crossprod(bits(A),bits(B),V)
+                t && $sm(m,p ? $Sym.:-(v) : v,C,Dimension{N}())
+            end
+            return m
+        end
+
         @inline function $(Symbol(:join,sb))(V::VectorSpace{N,D},m::SizedArray{Tuple{M},T,1,1},A::Bits,B::Bits,v::T) where {N,D,T<:SymField,M}
             if v ≠ 0 && !(hasdual(V) && isodd(A) && isodd(B))
                 $sb(m,parity(A,B,V) ? $Sym.:-(v) : v,A ⊻ B,Dimension{N}())


### PR DESCRIPTION
As pointed out in the literature cited by @orbots in #5 there is an interest in a generalized notation for the pseudoscalar quantity, sometimes written as `i` or `I` by various authors.

In this pull request, the goal is to debate and discuss the interpretation of `I` or `-I` with its signed value.

As it happens, `I` is also defined in Julia's `LinearAlgebra` library
```Julia
help?> I
search: I IO if Int in im Inf isa Int8 inv Int64 Int32 Int16 imag Inf64 Inf32 Inf16 Int128

  I

  An object of type UniformScaling, representing an identity matrix of any size.
```
and it is a `UniformScaling` type in general
```Julia
help?> UniformScaling
search: UniformScaling

  UniformScaling{T<:Number}

  Generically sized uniform scaling operator defined as a scalar times the identity operator,
  λ*I. See also I.

  Examples
  ≡≡≡≡≡≡≡≡≡≡

  julia> J = UniformScaling(2.)
  UniformScaling{Float64}
  2.0*I
  
  julia> A = [1. 2.; 3. 4.]
  2×2 Array{Float64,2}:
   1.0  2.0
   3.0  4.0
  
  julia> J*A
  2×2 Array{Float64,2}:
   2.0  4.0
   6.0  8.0
```
This pull request implements an interpretation of `UniformScaling` as a universal pseudoscalar element, which in correspondence with the new version of [AbstractTensors.jl](https://github.com/chakravala/AbstractTensors.jl) v0.1.4 just released enables full algebraic interoperability of `UniformScaling` and `I` as a universal pseudoscalar.

```Julia
function (V::VectorSpace)(s::UniformScaling{T}) where T
    SValue{V}(T<:Bool ? (s.λ ? -(one(T)) : one(T)) : s.λ,getbasis(V,(one(Bits)<<ndims(V))-1))
end
```

There is one question about it however; because the value of `I` is by default a signed interpretation
```Julia
julia> I
UniformScaling{Bool}
true*I
```
as you can see, the default `I` holds a `Bool` sign value of true, thus I have also taken the liberty of defining the default signed `I` as having a minus sign attached to it.

The advantage of defining the signed `I` with its signed interpretation is that it helps with hyperplanes
```Julia
julia> basis"+++"
(⟨+++⟩, v, v₁, v₂, v₃, v₁₂, v₁₃, v₂₃, v₁₂₃)

julia> i,j,k = I*v1, I*v2, I*v3
(-1v₂₃, 1v₁₃, -1v₁₂)

julia> i^2, j^2, k^2, i*j*k
(-1v, -1v, -1v, -1v)
```
where the multiplication on the left by `I*x` has the effect of `-complementright(x)`.

This is then also useful for making the generalized definition of cross product
```Julia
×(a,b) = I*(a∧b)
```
which also requires a negative sign interpretation (here already built-in).

This sign value might be confusing to some onlookers though, who are not familiar with the sign value associated to the `UniformScaling` and how it is interpreted in geometric algebra.

What do you think is the best interpretation of it here? I think the sign value is a good way to interpret it.

requesting feedback from @enkimute @arsenovic @hugohadfield